### PR TITLE
토큰 재발급 실패 이슈 해결

### DIFF
--- a/src/main/java/org/uni_bag/uni_bag_spring_boot_app/service/auth/AuthService.java
+++ b/src/main/java/org/uni_bag/uni_bag_spring_boot_app/service/auth/AuthService.java
@@ -98,7 +98,7 @@ public class AuthService {
 
         // 토큰 재발행
         String reIssuedAccessToken = jwtTokenProvider.reIssueAccessToken(resolvedAccessToken);
-        redisService.delete(resolvedAccessToken);
+        redisService.delete(resolvedRefreshToken);
         redisService.save(resolvedRefreshToken, reIssuedAccessToken);
         return TokenReIssueDto.of(reIssuedAccessToken);
 


### PR DESCRIPTION
토큰 재발급 실패 이슈를 해결하였습니다.
redis key값을 전달할 때 잘못된 값을 전달하여 발생한 오류였습니다.