### PR TITLE
feat: 강의 조회 기능 향상 Like 연산

### DIFF
--- a/src/main/java/org/uni_bag/uni_bag_spring_boot_app/repository/DgLectureSpecifications.java
+++ b/src/main/java/org/uni_bag/uni_bag_spring_boot_app/repository/DgLectureSpecifications.java
@@ -22,16 +22,16 @@ public class DgLectureSpecifications {
         return (root, query, cb) -> semester != null ? cb.equal(root.get("semester"), semester) : null;
     }
 
-    public static Specification<DgLecture> ocLike(String oc) {
-        return (root, query, cb) -> cb.like(root.get("offeringCollege"), oc);
+    public static Specification<DgLecture> ocEquals(String oc) {
+        return (root, query, cb) -> cb.equal(root.get("offeringCollege"), oc);
     }
 
-    public static Specification<DgLecture> odLike(String od) {
-        return (root, query, cb) -> cb.like(root.get("offeringDepartment"), od);
+    public static Specification<DgLecture> odEquals(String od) {
+        return (root, query, cb) -> cb.equal(root.get("offeringDepartment"), od);
     }
 
-    public static Specification<DgLecture> omLike(String om) {
-        return (root, query, cb) -> cb.like(root.get("offeringMajor"), om);
+    public static Specification<DgLecture> omEquals(String om) {
+        return (root, query, cb) -> cb.equal(root.get("offeringMajor"), om);
     }
     public static Specification<DgLecture> gradeEquals(String grade) {
         return (root, query, cb) -> cb.equal(root.get("targetGrade"), grade);

--- a/src/main/java/org/uni_bag/uni_bag_spring_boot_app/service/lectureSearch/LectureSearchService.java
+++ b/src/main/java/org/uni_bag/uni_bag_spring_boot_app/service/lectureSearch/LectureSearchService.java
@@ -31,9 +31,9 @@ public class LectureSearchService {
 
         spec = spec.and(DgLectureSpecifications.yearEquals(year));
         spec = spec.and(DgLectureSpecifications.semesterEquals(semester));
-        if (StringUtils.hasText(oc)) spec = spec.and(DgLectureSpecifications.ocLike("%" + oc + "%"));
-        if (StringUtils.hasText(od)) spec = spec.and(DgLectureSpecifications.odLike("%" +od + "%"));
-        if (StringUtils.hasText(om)) spec = spec.and(DgLectureSpecifications.omLike("%" + om + "%"));
+        if (oc != null) spec = spec.and(DgLectureSpecifications.ocEquals(oc));
+        if (od != null) spec = spec.and(DgLectureSpecifications.odEquals(od));
+        if (om != null) spec = spec.and(DgLectureSpecifications.omEquals(om));
         if (grade != null) spec = spec.and(DgLectureSpecifications.gradeEquals(grade+"학년"));
         if (StringUtils.hasText(professor)) spec = spec.and(DgLectureSpecifications.professorLike("%" + professor + "%"));
         if (StringUtils.hasText(lectureName)) spec = spec.and(DgLectureSpecifications.lectureNameLike("%" + lectureName + "%"));


### PR DESCRIPTION
이슈 #56 의 문제를 해결하기 위하여 Like 연산을 하였습니다. 
요청한 담당교수명, 강의명 뿐만 아닌 개설대학, 개설학과, 개설전공 또한 Like 연산을 하도록 변경하였습니다. 
혹시 개설대학, 개설학과, 개설전공을 사용자가 아닌 프론트단에서 고정적으로 설정한다면 개설대학, 개설학과, 개설전공의 경우 롤백하도록 하겠습니다.