### PR TITLE
토큰 재발행 이슈 해결

### DIFF
--- a/src/main/java/org/uni_bag/uni_bag_spring_boot_app/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/uni_bag/uni_bag_spring_boot_app/filter/JwtAuthenticationFilter.java
@@ -72,4 +72,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.error("IO Exception: {}", ex.getMessage());
         }
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String requestURI  = request.getRequestURI();
+        return requestURI.matches("^/api/auth/login$") ||
+                requestURI.matches("^/api/auth/logout$") ||
+                requestURI.matches("^/api/auth/refreshToken$") ||
+                requestURI.matches("^/h2-console/.*$") ||
+                requestURI.matches("^/images/.*$") ||
+                requestURI.matches("^/swagger-ui/.*$") ||
+                requestURI.matches("^/v3/api-docs/.*$") ||
+                requestURI.matches("^/actuator/.*$") ||
+                requestURI.matches("^/api/server/env$");
+    }
 }


### PR DESCRIPTION
## 문제 분석
#57 과 같이 토큰이 재발행 되지 않는 이슈가 발견되었습니다.
디버깅을 해본 결과 사용자가 토큰 재발행을 위해 헤더에 AccessToken과 RefreshToken을 담아 서버로 요청을 보내고 `JwtAuthenticationFilter`에서 헤더에 담긴 AccessToken를 통해 유저정보를 분석하는 과정에서 토큰이 이미 만료되었기 때문에 Filter단에 403에러를 응답하였습니다. 이로 인해 요청이 Controller까지 전달되지 못해 토큰이 재발행이 되지 않았습닏.

## 문제 해결
`JwtAuthenticationFilter`에 토큰 재발행 API뿐만 사용자 인증을 필요로 하지 않으며 `JwtAuthenticationFilter`를 거칠 필요가 없는 모든 API들에 대해 해당 필터를 거치지 않도록 코드를 수정하였습니다.