### PR TITLE
30분 전 수업 알림 기능 구현

### DIFF
--- a/src/main/java/org/uni_bag/uni_bag_spring_boot_app/StartupScheduler.java
+++ b/src/main/java/org/uni_bag/uni_bag_spring_boot_app/StartupScheduler.java
@@ -6,8 +6,11 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.uni_bag.uni_bag_spring_boot_app.domain.Assignment;
+import org.uni_bag.uni_bag_spring_boot_app.domain.TimeTable;
 import org.uni_bag.uni_bag_spring_boot_app.repository.AssignmentRepository;
+import org.uni_bag.uni_bag_spring_boot_app.repository.TimeTableRepository;
 import org.uni_bag.uni_bag_spring_boot_app.service.assignment.AssignmentNotificationService;
+import org.uni_bag.uni_bag_spring_boot_app.service.assignment.TimetableNotificationService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,12 +20,15 @@ import java.util.List;
 @Slf4j
 public class StartupScheduler {
     private final AssignmentRepository assignmentRepository;
+    private final TimeTableRepository timeTableRepository;
+
     private final AssignmentNotificationService notificationService;
+    private final TimetableNotificationService timetableNotificationService;
 
     @Bean
     public ApplicationRunner initializeScheduledTasks() {
         return args -> {
-            log.info("Notification scheduling started");
+            log.info("Assignment notification scheduling started");
 
             List<Assignment> assignments = assignmentRepository.findAssignmentsAfterOneHour(
                     LocalDateTime.now().plusHours(1),
@@ -32,6 +38,15 @@ public class StartupScheduler {
 
             for (Assignment assignment : assignments) {
                 notificationService.scheduleNotification(assignment);
+            }
+
+            log.info("Lecture Reminder notification scheduling completed.");
+
+            List<TimeTable> timeTables = timeTableRepository.findAllByIsPrimary(true);
+            log.info("Loaded {} primary timeTables from the database.", timeTables.size());
+
+            for (TimeTable timeTable : timeTables) {
+                timetableNotificationService.scheduleNotification(timeTable);
             }
 
             log.info("Notification scheduling completed.");

--- a/src/main/java/org/uni_bag/uni_bag_spring_boot_app/repository/TimeTableRepository.java
+++ b/src/main/java/org/uni_bag/uni_bag_spring_boot_app/repository/TimeTableRepository.java
@@ -12,4 +12,5 @@ public interface TimeTableRepository extends JpaRepository<TimeTable, Long> {
     Optional<TimeTable> findByIdAndUser(Long id, User user);
     List<TimeTable> findAllByUser(User user);
     Optional<TimeTable> findByUserAndIsPrimary(User user, boolean isPrimary);
+    List<TimeTable> findAllByIsPrimary(boolean isPrimary);
 }

--- a/src/main/java/org/uni_bag/uni_bag_spring_boot_app/service/assignment/TimetableNotificationService.java
+++ b/src/main/java/org/uni_bag/uni_bag_spring_boot_app/service/assignment/TimetableNotificationService.java
@@ -1,0 +1,122 @@
+package org.uni_bag.uni_bag_spring_boot_app.service.assignment;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Service;
+import org.uni_bag.uni_bag_spring_boot_app.constant.AssignmentAlarmType;
+import org.uni_bag.uni_bag_spring_boot_app.domain.*;
+import org.uni_bag.uni_bag_spring_boot_app.repository.DgLectureTimeRepository;
+import org.uni_bag.uni_bag_spring_boot_app.repository.TimeTableLectureRepository;
+import org.uni_bag.uni_bag_spring_boot_app.service.fcm.FcmService;
+
+import java.text.SimpleDateFormat;
+import java.time.*;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class TimetableNotificationService {
+    private final ThreadPoolTaskScheduler taskScheduler;
+    private final FcmService fcmService;
+    private final TimeTableLectureRepository timeTableLectureRepository;
+    private final Map<String, ScheduledFuture
+            <?>> scheduledTasks = new ConcurrentHashMap<>();
+
+    public void scheduleNotification(TimeTable timeTable) {
+        List<TimeTableLecture> foundTimetableLectures = timeTableLectureRepository.findAllByTimeTable(timeTable);
+
+        int subId = 1;
+        for (TimeTableLecture timeTableLecture : foundTimetableLectures) {
+            DgLecture foundLecture = timeTableLecture.getLecture();
+            List<DgLectureTime> foundLectureTimes = foundLecture.getDgLectureTimes();
+            for (DgLectureTime lectureTime : foundLectureTimes) {
+                LocalDate today = LocalDate.now();
+                // TemporalAdjusters.nextOrSame(DayOfWeek.WEDNESDAY)
+                // 오늘이 수요일이면 그대로 반환
+                // 오늘이 수요일이 아니면 다음 수요일을 반환
+                LocalDate scheduledLocalDate = today.with(TemporalAdjusters.nextOrSame(getDayOfWeek(lectureTime.getDayOfWeek())));
+
+                // 예정된 수업시간 30분 전
+                LocalDateTime scheduledLocalDateTime = LocalDateTime.of(scheduledLocalDate, lectureTime.getStartTime().toLocalTime()).minusMinutes(30);
+
+                // 스케줄 예정인 시간이 이미 지났다면
+                if(scheduledLocalDateTime.isBefore(LocalDateTime.now())) {
+                    scheduledLocalDateTime = scheduledLocalDateTime.plusWeeks(1);
+                }
+
+                String scheduleId = timeTable.getId() + "_" + subId++;
+
+                scheduleTask(scheduleId, timeTable.getUser(), foundLecture, lectureTime, scheduledLocalDateTime);
+            }
+        }
+    }
+
+    private void scheduleTask(String scheduleId, User notifyTargetUser, DgLecture lecture, DgLectureTime lectureTime, LocalDateTime notifyTime) {
+        log.info("Attempting to schedule lecture reminder task : schedule id: {} | notifyTime id: {}", scheduleId, notifyTime.toString());
+
+        Instant instant = notifyTime.atZone(ZoneId.systemDefault()).toInstant();
+
+        ScheduledFuture<?> scheduledTask = taskScheduler.schedule(() -> {
+            log.info("Executing scheduled notification: {}", scheduleId);
+
+            String title = "잠시후 " + lecture.getCourseName() + " 수업이 있어요";
+            String description = lecture.getClassroom() + " " + new SimpleDateFormat("HH시 mm분").format(lectureTime.getStartTime());
+
+            fcmService.sendNotification(notifyTargetUser, title, description);
+            scheduledTasks.remove(scheduleId); // 완료 후 삭제
+            log.info("Completed and removed scheduled task: {}", scheduleId);
+
+            LocalDateTime nextNotifyTime = notifyTime.plusWeeks(1);
+            scheduleTask(scheduleId, notifyTargetUser, lecture, lectureTime, nextNotifyTime);
+
+        }, instant);
+
+        scheduledTasks.put(scheduleId, scheduledTask);
+        log.info("Scheduled task successfully: {}", scheduleId);
+
+    }
+
+    public void cancelNotification(TimeTable timeTable) {
+        int times = 0;
+        List<TimeTableLecture> foundTimetableLectures = timeTableLectureRepository.findAllByTimeTable(timeTable);
+        for (TimeTableLecture timeTableLecture : foundTimetableLectures) {
+            times += timeTableLecture.getLecture().getDgLectureTimes().size();
+        }
+
+        for(int subId = 1; subId <= times; subId++) {
+            String scheduleId = timeTable.getId() + "_" + subId;
+            ScheduledFuture<?> scheduledTask = scheduledTasks.remove(scheduleId);
+
+            if (scheduledTask != null) {
+                scheduledTask.cancel(false); // 현재 실행 중이 아닌 경우만 취소
+                log.info("Cancelled scheduled task: {}", scheduleId);
+            } else {
+                log.warn("No scheduled task found for: {}", scheduleId);
+            }
+        }
+
+    }
+
+    private DayOfWeek getDayOfWeek(String day) {
+        final Map<String, DayOfWeek> dayMapping = Map.of(
+                "월", DayOfWeek.MONDAY,
+                "화", DayOfWeek.TUESDAY,
+                "수", DayOfWeek.WEDNESDAY,
+                "목", DayOfWeek.THURSDAY,
+                "금", DayOfWeek.FRIDAY,
+                "토", DayOfWeek.SATURDAY,
+                "일", DayOfWeek.SUNDAY
+        );
+
+        return dayMapping.getOrDefault(day, null);
+    }
+}


### PR DESCRIPTION
#65 에서 요구한 30분 전 수업 알림 기능을 구현하였습니다.

## 동작흐름
동작흐름을 간단하게 설명하면 다음과 같습니다.

### primary table 수정
- primary table이 새롭게 지정되면 기존 primary table에 속한 강의들의 모든 알림 스케쥴을 삭제합니다(기존에 primary table이 있을 경우).
- 새로운 primary table의 강의 목록과 강의 시간을 조회하여 {강의 아이디}-{서브 아이디} 형태로 스케쥴 아이디를 지정하고 TaskSchedule 객체를 활용하여 강의 시간 30분 전에 FCM으로 푸시 알림을 전송하도록 스케쥴을 생성합니다.

### primary table 삭제
- primary table에 속한 강의들의 모든 알림 스케쥴을 삭제합니다.

### 서버 재시작 시
- 스케쥴을 Map 자료구조를 이용하여 key(스케쥴 아이디)-value(스케쥴 객체)를 관리합니다.
- 그렇기에 서버가 종료되면 해당 Map객체 또한 삭제됩니다.
- 서버 시작 시 스케쥴이 등록될 수 있도록 모든 primary table을 조회하여 스케쥴을 생성합니다.